### PR TITLE
Enable Dependabot for npm dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    target-branch: develop
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: chore(deps)


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` for weekly npm dependency scans at the repo root.
- Opens PRs against `develop` (not `master`) to match THFF branch flow.
- Groups minor and patch updates into fewer PRs; major bumps still arrive individually.

## Notes
GitHub reads Dependabot config from the **default branch** (`master`). Dependabot will not run until this file is promoted through `develop` → `staging` → `master`.

Security update PRs (if enabled in repo settings) are separate from these version-update PRs.

## Test plan
- [ ] Merge to `develop`, then promote to `master`
- [ ] Confirm Dependabot appears under repo **Insights → Dependency graph → Dependabot**
- [ ] Verify first scheduled PR targets `develop` on the next Monday run (or trigger manually from Dependabot tab if available)

Made with [Cursor](https://cursor.com)