### PR TITLE
chore: bump version to 5.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thff-be",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thff-be",
-      "version": "5.6.0",
+      "version": "5.6.1",
       "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.1547.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-be",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "hagen family foundation backend",
   "main": "app.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump app version to **5.6.1** for the security dependency and org profile save release

## Test plan
- [ ] Health endpoint reports `5.6.1`


Made with [Cursor](https://cursor.com)