### PR TITLE
fix(501c3): use App Runner instance role for S3 uploads

### DIFF
--- a/src/config/s3.js
+++ b/src/config/s3.js
@@ -1,6 +1,7 @@
 import AWS from 'aws-sdk';
 
 import Config from './config.js';
+import Logger from '../utils/logger.js';
 
 /** Mitigate GHSA-j965-2qgj-vjmq: reject unexpected region strings before SDK use. */
 function assertSafeAwsRegion(region) {
@@ -13,11 +14,18 @@ function assertSafeAwsRegion(region) {
 
 const safeRegion = assertSafeAwsRegion(Config.region);
 
-AWS.config.update({
-  accessKeyId: Config.accessKey,
-  secretAccessKey: Config.secretAccessKey,
-  region: safeRegion,
-});
+// Only set static credentials when both are present. Passing empty strings can
+// shadow the default provider chain (env vars / EC2 instance role), which is how
+// deployed environments (e.g. Elastic Beanstalk) are expected to authenticate.
+const awsConfig = { region: safeRegion };
+if (Config.accessKey && Config.secretAccessKey) {
+  awsConfig.accessKeyId = Config.accessKey;
+  awsConfig.secretAccessKey = Config.secretAccessKey;
+} else {
+  Logger.warn('AWS static credentials not set; relying on default provider chain (instance role / env).');
+}
+
+AWS.config.update(awsConfig);
 
 const s3 = new AWS.S3();
 

--- a/src/controllers/organization/organizations-501c3.js
+++ b/src/controllers/organization/organizations-501c3.js
@@ -35,6 +35,15 @@ export const upload501c3Doc = async (req, res) => {
 
     console.log('inside the upload org', org);
 
+    if (!req.files || !req.files.doc501c3) {
+      Logger.error(
+        `No file received for org ${orgID}. content-type=${req.headers['content-type']} content-length=${req.headers['content-length']}`
+      );
+      return res
+        .status(400)
+        .send({ code: "ORG501C3005", message: 'No file received. Please re-select the document and try again.' });
+    }
+
     let organizationID = org.id;
 
     Logger.info("orgID", orgID);
@@ -91,7 +100,10 @@ export const upload501c3Doc = async (req, res) => {
     });
   }
   catch (e) {
-    Logger.error(`Error Uploading 501c3 for org ${orgID}`);
+    Logger.error(`Error Uploading 501c3 for org ${orgID}: ${e && e.message ? e.message : e}`);
+    if (e && e.stack) {
+      Logger.error(e.stack);
+    }
     return res
       .status(400)
       .send({ code: "ORG501C3002", message: 'Error Uploading 501c3' });
@@ -282,7 +294,7 @@ function uploads3(req, orgId) {
 
       if (err) {
         console.log('Error uploading file:', err);
-        return reject();
+        return reject(err);
       } else {
 
         Logger.info(`File ${fileName} uploaded successfully`);


### PR DESCRIPTION
## Summary

501(c)(3) uploads returned a generic `400 ORG501C3002` on **staging and production** while working locally.

**Root cause:** the deployed App Runner services authenticate to S3 with static `AWS_KEY`/`AWS_SECRET_KEY` env vars that are stale/invalid. Those override the App Runner **instance role** (`AppRunnerInstanceRole`), which already grants `s3:PutObject`/`GetObject`/`DeleteObject` on `thff-501c3-docs`. The handler then swallowed the real error behind a generic 400.

## Changes

- **`src/config/s3.js`**: only set static AWS credentials when both are present; otherwise fall back to the default provider chain (instance role). Logs a warning when static keys are absent.
- **`src/controllers/organization/organizations-501c3.js`**:
  - Guard a missing upload file with a clear `ORG501C3005` response instead of throwing.
  - Log the real error (`message` + stack) in the catch block.
  - `uploads3` now rejects with the actual S3 error instead of an empty rejection.

## Deploy note

Staging/production App Runner should have `AWS_KEY`/`AWS_SECRET_KEY` **removed** so the app uses the instance role. Staging keys have already been removed; with this code deployed, uploads will authenticate via the role.

## Test plan

- [ ] Merge to `develop`, promote `develop` → `staging` (App Runner auto-deploys staging)
- [ ] Upload a 501(c)(3) on staging → expect 200
- [ ] Verify object lands in `s3://thff-501c3-docs/`
- [ ] Then remove static keys on production + promote to `master`

Made with [Cursor](https://cursor.com)