### PR TITLE
fix(uuid): Node 18 crypto.randomUUID for 501c3 uploads

### DIFF
--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 
 import Logger from "./logger.js";
 
@@ -19,5 +19,5 @@ export const generateCode = () => {
 }
 
 export const generateUUID = () => {
-  return uuidv4();
+  return randomUUID();
 }


### PR DESCRIPTION
## Summary

The **actual** root cause of the 501(c)(3) upload 400s on staging/production.

`generateUUID()` used the `uuid` v14 package, which relies on the global `crypto` (Web Crypto API). That global does **not** exist on **Node 18** (the App Runner runtime), so `uuidv4()` threw `crypto is not defined`. Since the S3 key is built with `generateUUID()` *before* the upload runs, every upload failed with a generic 400 — while local (Node 22, which has global `crypto`) worked.

Surfaced via the error logging added in #318.

## Change

- `src/utils/util.js`: use Node's built-in `crypto.randomUUID()` (available Node 14.17+) instead of the `uuid` package.

## Test plan
- [ ] Merge to develop, promote develop → staging
- [ ] Upload a 501(c)(3) on staging → expect 200
- [ ] Confirm object in s3://thff-501c3-docs/
- [ ] Then promote to master (production)

Made with [Cursor](https://cursor.com)