### PR TITLE
Promote: Node 18 crypto.randomUUID 501c3 upload fix to staging

### DIFF
--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 
 import Logger from "./logger.js";
 
@@ -19,5 +19,5 @@ export const generateCode = () => {
 }
 
 export const generateUUID = () => {
-  return uuidv4();
+  return randomUUID();
 }


### PR DESCRIPTION
Promotes the real 501(c)(3) upload fix (#320) from develop to staging.

Root cause: uuid v14 relies on a global `crypto` absent on Node 18 (App Runner runtime), so `generateUUID()` threw before the S3 upload. Now uses Node's built-in `crypto.randomUUID()`.

Staging App Runner auto-deploys from this branch.

## Test plan
- [ ] Upload a 501(c)(3) on staging → expect 200

Made with [Cursor](https://cursor.com)