### PR TITLE
Release: 501c3 upload fix (Node 18 crypto.randomUUID) to production

### DIFF
--- a/src/config/s3.js
+++ b/src/config/s3.js
@@ -1,6 +1,7 @@
 import AWS from 'aws-sdk';
 
 import Config from './config.js';
+import Logger from '../utils/logger.js';
 
 /** Mitigate GHSA-j965-2qgj-vjmq: reject unexpected region strings before SDK use. */
 function assertSafeAwsRegion(region) {
@@ -13,11 +14,18 @@ function assertSafeAwsRegion(region) {
 
 const safeRegion = assertSafeAwsRegion(Config.region);
 
-AWS.config.update({
-  accessKeyId: Config.accessKey,
-  secretAccessKey: Config.secretAccessKey,
-  region: safeRegion,
-});
+// Only set static credentials when both are present. Passing empty strings can
+// shadow the default provider chain (env vars / EC2 instance role), which is how
+// deployed environments (e.g. Elastic Beanstalk) are expected to authenticate.
+const awsConfig = { region: safeRegion };
+if (Config.accessKey && Config.secretAccessKey) {
+  awsConfig.accessKeyId = Config.accessKey;
+  awsConfig.secretAccessKey = Config.secretAccessKey;
+} else {
+  Logger.warn('AWS static credentials not set; relying on default provider chain (instance role / env).');
+}
+
+AWS.config.update(awsConfig);
 
 const s3 = new AWS.S3();
 

--- a/src/controllers/organization/organizations-501c3.js
+++ b/src/controllers/organization/organizations-501c3.js
@@ -35,6 +35,15 @@ export const upload501c3Doc = async (req, res) => {
 
     console.log('inside the upload org', org);
 
+    if (!req.files || !req.files.doc501c3) {
+      Logger.error(
+        `No file received for org ${orgID}. content-type=${req.headers['content-type']} content-length=${req.headers['content-length']}`
+      );
+      return res
+        .status(400)
+        .send({ code: "ORG501C3005", message: 'No file received. Please re-select the document and try again.' });
+    }
+
     let organizationID = org.id;
 
     Logger.info("orgID", orgID);
@@ -91,7 +100,10 @@ export const upload501c3Doc = async (req, res) => {
     });
   }
   catch (e) {
-    Logger.error(`Error Uploading 501c3 for org ${orgID}`);
+    Logger.error(`Error Uploading 501c3 for org ${orgID}: ${e && e.message ? e.message : e}`);
+    if (e && e.stack) {
+      Logger.error(e.stack);
+    }
     return res
       .status(400)
       .send({ code: "ORG501C3002", message: 'Error Uploading 501c3' });
@@ -282,7 +294,7 @@ function uploads3(req, orgId) {
 
       if (err) {
         console.log('Error uploading file:', err);
-        return reject();
+        return reject(err);
       } else {
 
         Logger.info(`File ${fileName} uploaded successfully`);

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 
 import Logger from "./logger.js";
 
@@ -19,5 +19,5 @@ export const generateCode = () => {
 }
 
 export const generateUUID = () => {
-  return uuidv4();
+  return randomUUID();
 }


### PR DESCRIPTION
Promotes the 501(c)(3) upload fix to production after staging QA passed.

## Root cause
generateUUID() used uuid v14, which needs a global crypto absent on Node 18 (App Runner runtime). It threw "crypto is not defined" before the S3 upload, failing every upload with a generic 400. Fixed by using Node's built-in crypto.randomUUID().

Also includes the S3 instance-role fallback + real error logging (#318).

## Staging QA
Tiny and ~2MB uploads returned 200; object stored in s3://thff-501c3-docs/ via the App Runner instance role.

## Post-merge (production)
Prod App Runner auto-deploys from master. Static AWS keys will be removed from the prod service so it uses the instance role (matches staging).

## Test plan
- [ ] Prod redeploys
- [ ] Upload 501(c)(3) for org pTSya (Orlando Robotics) then expect 200

Made with [Cursor](https://cursor.com)