### PR TITLE
Release v5.6.2: director+ can edit/submit any org's proposals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thff-be",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thff-be",
-      "version": "5.6.1",
+      "version": "5.6.2",
       "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.1547.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-be",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "description": "hagen family foundation backend",
   "main": "app.js",
   "type": "module",

--- a/src/controllers/proposal/proposals.js
+++ b/src/controllers/proposal/proposals.js
@@ -180,7 +180,7 @@ function proposalOrgMongoId(proposal) {
 
 /**
  * Who may call PUT /proposal/:id
- * - Composer (`draft` / `ready_to_submit`): the creator (`createdBy`), or if `createdBy` is missing, any member of the proposal’s organization (legacy rows).
+ * - Composer (`draft` / `ready_to_submit`): the creator (`createdBy`); if `createdBy` is missing, any member of the proposal’s organization (legacy rows); or any foundation director (`accessLevel` > 1) helping an organization finish/submit its proposal.
  * - Submitted: members of the proposal’s organization (collaborative edits on the proposal page) or any foundation director (`accessLevel` > 1).
  */
 async function canUserUpdateProposal(decoded, before) {
@@ -205,6 +205,12 @@ async function canUserUpdateProposal(decoded, before) {
       return { ok: true };
     }
     if (!creator && inProposalOrg) {
+      return { ok: true };
+    }
+    // Director and up (accessLevel > 1: director, president, admin) can edit and submit composer
+    // drafts on behalf of an organization (e.g. helping an applicant finish their proposal). This
+    // mirrors the access these roles already have to GET any proposal and edit submitted ones below.
+    if (isDirector) {
       return { ok: true };
     }
     return {


### PR DESCRIPTION
## Summary
Promote v5.6.2 to production.

- Directors, presidents, and admins (`accessLevel > 1`) can now edit and submit composer drafts for any organization (fixes `You can only edit your own draft proposals.` when staff help an org submit).
- Version bump to `5.6.2`.

Promoted via: develop → staging (#323) → master.

## Test plan
- [ ] Verify in production that a director/president can open an org's draft, complete it, and submit.
- [ ] Verify level-1 applicants are unaffected (still restricted to their own drafts).

Made with [Cursor](https://cursor.com)