### PR TITLE
Promote develop → staging: meeting live sync (Socket.IO + Redis adapter)

### DIFF
--- a/.platform/nginx/conf.d/elasticbeanstalk/websocket.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/websocket.conf
@@ -1,0 +1,18 @@
+# Elastic Beanstalk (Amazon Linux 2/2023) reverse-proxy override for Socket.IO.
+# Files under .platform/nginx/conf.d/elasticbeanstalk/ are included INSIDE the
+# EB server block, so a `location` is valid here. This ensures the WebSocket
+# `Upgrade`/`Connection` headers are forwarded to the Node app (default port 8080),
+# which the platform's default `location /` does not always do.
+location /socket.io/ {
+    proxy_pass http://127.0.0.1:8080;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    # Keep long-lived WebSocket connections open.
+    proxy_read_timeout 86400;
+    proxy_send_timeout 86400;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "5.6.2",
       "license": "MIT",
       "dependencies": {
+        "@socket.io/redis-adapter": "^8.3.0",
         "aws-sdk": "^2.1547.0",
         "bcrypt": "^5.1.1",
         "bcryptjs": "^2.4.3",
@@ -23,6 +24,8 @@
         "jsonwebtoken": "^9.0.2",
         "mailgun.js": "^13.2.0",
         "mongoose": "^8.0.1",
+        "redis": "^6.1.0",
+        "socket.io": "^4.8.3",
         "uuid": "^14.0.0",
         "winston": "^3.11.0"
       },
@@ -623,6 +626,136 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-6.1.0.tgz",
+      "integrity": "sha512-Rzascjd9J9bJsM45T/Z9CTg1QY/B63B6YO8QorLVMeXnbBDsKiSCVR/+GQ061hYPk8FpTzWmPY8tAv2sT+JEtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.1.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-6.1.0.tgz",
+      "integrity": "sha512-7u1LefkezJF0HESlhO7ZFLEPfyY+NejP3SGv+Z4pGaT3oM5GVVLa0u3f4rDLUrcw+SRo8IlX9Y8JAONeDdg1Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-6.1.0.tgz",
+      "integrity": "sha512-/GFjQA6bu5pG9ClCJAI5Xx4bNXe7UTpxBBlIupBNTrn1+nY860apGnYJuaSCDV2BmEbTidpa7O2qa28oxKx+rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.1.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-6.1.0.tgz",
+      "integrity": "sha512-kS5agg+3yZbrdrt8omrew7FLCD8eOm7tarG1CROekPBRe+QGDR9aOpnHIQaYsYi6wPRTH70nQiF06AIjgURefQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.1.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-6.1.0.tgz",
+      "integrity": "sha512-uIDBtV8MmG/xpJsRqbGSO4iX6ryj37MLMP82lRpFvI7ykAVe5GyqgxigEbU+uZNv9kDPNMKw3dvI/S/J1BNBzA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.1.0"
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@socket.io/redis-adapter": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-8.3.0.tgz",
+      "integrity": "sha512-ly0cra+48hDmChxmIpnESKrc94LjRL80TEmZVscuQ/WWkRP81nNj8W8cCGMqbI4L6NCuAaPRSzZF1a9GlAxxnA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.1",
+        "notepack.io": "~3.0.1",
+        "uid2": "1.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "socket.io-adapter": "^2.5.4"
+      }
+    },
+    "node_modules/@socket.io/redis-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
@@ -641,6 +774,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -872,6 +1014,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.40",
@@ -1174,6 +1325,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
@@ -1310,11 +1470,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -1446,6 +1607,36 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/es-define-property": {
@@ -3088,11 +3279,6 @@
         "url": "https://opencollective.com/mongoose"
       }
     },
-    "node_modules/mongoose/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
     "node_modules/mpath": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
@@ -3113,9 +3299,10 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -3254,6 +3441,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/notepack.io": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-3.0.1.tgz",
+      "integrity": "sha512-TKC/8zH5pXIAMVQio2TvVDTtPRX+DJPHDqjRbxogtFiByHyzKmy96RA0JtCQJ+WouyyL4A10xomQzgbUT+1jCg==",
+      "license": "MIT"
     },
     "node_modules/npmlog": {
       "version": "5.0.1",
@@ -3563,6 +3756,22 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redis": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-6.1.0.tgz",
+      "integrity": "sha512-0kvUPM8RHP/ZMa0xYaDTcG5e8tIGW6kz6MToVT0V8iOnk6bkXp2jncGRGe2bZEk41lZwiDspUqjZCSk5ohjcKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "6.1.0",
+        "@redis/client": "6.1.0",
+        "@redis/json": "6.1.0",
+        "@redis/search": "6.1.0",
+        "@redis/time-series": "6.1.0"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3701,12 +3910,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/serve-static": {
@@ -3884,6 +4087,47 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
+      "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.21.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/source-map": {
@@ -4119,11 +4363,26 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/uid2": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-1.0.0.tgz",
+      "integrity": "sha512-+I6aJUv63YAcY9n4mQreLUt0d4lvwkkopDNmpomkAUz0fAkEMV9pRWxN0EjhW1YfRhcuyHg2v3mwddCDW1+LFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -4355,6 +4614,27 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml2js": {
       "version": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Logan Born",
   "license": "MIT",
   "dependencies": {
+    "@socket.io/redis-adapter": "^8.3.0",
     "aws-sdk": "^2.1547.0",
     "bcrypt": "^5.1.1",
     "bcryptjs": "^2.4.3",
@@ -31,6 +32,8 @@
     "jsonwebtoken": "^9.0.2",
     "mailgun.js": "^13.2.0",
     "mongoose": "^8.0.1",
+    "redis": "^6.1.0",
+    "socket.io": "^4.8.3",
     "uuid": "^14.0.0",
     "winston": "^3.11.0"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,5 @@
 //packages
+import http from 'http';
 import express from 'express';
 import helmet from "helmet";
 import cors from 'cors';
@@ -8,6 +9,8 @@ import { Config } from './config/index.js';
 
 //routes
 import routes from './routes/index.js';
+//realtime
+import { initSocket, closeSocket } from './socket/index.js';
 
 const app = express();
 const port = Config.appPort;
@@ -20,7 +23,28 @@ app.use(helmet())
 
 routes(app);
 
-// eslint-disable-next-line no-unused-vars
-const server = app.listen(port, () => {
+// Wrap Express in an HTTP server so Socket.IO can share the same port.
+const server = http.createServer(app);
+initSocket(server);
+
+server.listen(port, () => {
   console.log(`THFF listening on port ${port}`)
 })
+
+// Graceful shutdown: close sockets + Redis, then the HTTP server.
+const shutdown = async (signal) => {
+  console.log(`Received ${signal}, shutting down...`);
+  // Force-exit if cleanup hangs.
+  const forceExit = setTimeout(() => process.exit(1), 10000);
+  forceExit.unref();
+  try {
+    // io.close() also closes the underlying HTTP server.
+    await closeSocket();
+  } catch (err) {
+    console.error(`Error during shutdown: ${err.message}`);
+  }
+  process.exit(0);
+};
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -22,6 +22,9 @@ const Config = {
   //mongodb
   databaseURI: process.env.DATABASE_URI,
 
+  /** Redis connection URL. When set, enables the Socket.IO Redis adapter for multi-instance fan-out. */
+  redisURL: process.env.REDIS_URL,
+
   //AWS
   accessKey: process.env.AWS_KEY,
   secretAccessKey: process.env.AWS_SECRET_KEY,

--- a/src/controllers/admin/meetings.js
+++ b/src/controllers/admin/meetings.js
@@ -12,6 +12,7 @@ import {
   logRestored,
   logSetAside,
 } from "../../utils/meeting-events.js";
+import { emitMeetingUpdate } from "../../socket/index.js";
 
 const ACCESS_LEVEL_PRESIDENT = 3;
 
@@ -253,6 +254,7 @@ export const updateMeeting = async (req, res) => {
     await meeting.save();
 
     const populated = await populateMeeting(id);
+    emitMeetingUpdate(populated);
 
     Logger.info(`Meeting updated: ${id}`);
     return res.status(200).json(populated);
@@ -327,6 +329,7 @@ export const updateAllocations = async (req, res) => {
     await meeting.save();
 
     const populated = await populateMeeting(id);
+    emitMeetingUpdate(populated);
 
     Logger.info(`Meeting allocations updated: ${id}`);
     return res.status(200).json(populated);
@@ -365,6 +368,7 @@ export const completeMeeting = async (req, res) => {
     await meeting.save();
 
     const populated = await populateMeeting(id);
+    emitMeetingUpdate(populated);
 
     Logger.info(
       `Meeting completed: ${id}${unfundedSetAside ? ` (${unfundedSetAside} unfunded set aside)` : ''}`
@@ -396,6 +400,8 @@ export const archiveMeeting = async (req, res) => {
 
     meeting.archived = archived;
     await meeting.save();
+
+    emitMeetingUpdate(await populateMeeting(id));
 
     Logger.info(`Meeting ${id} archived: ${archived}`);
     return res.status(200).json(meeting);
@@ -446,6 +452,7 @@ export const removeAllocation = async (req, res) => {
     await meeting.save();
 
     const updated = await populateMeeting(id);
+    emitMeetingUpdate(updated);
 
     Logger.info(`Allocation ${allocationId} set aside on meeting ${id}`);
     return res.status(200).json(updated);
@@ -502,6 +509,7 @@ export const setAllocationActive = async (req, res) => {
     await meeting.save();
 
     const updated = await populateMeeting(id);
+    emitMeetingUpdate(updated);
     Logger.info(`Allocation ${allocationId} activeInMeeting=${active} on meeting ${id}`);
     return res.status(200).json(updated);
   } catch (err) {
@@ -572,6 +580,9 @@ export const syncEligibleProposalsToMeeting = async (req, res) => {
     }
 
     const populated = await populateMeeting(id);
+    if (changed) {
+      emitMeetingUpdate(populated);
+    }
     Logger.info(`Meeting ${id} proposal sync: ${changed ? 'updated' : 'no changes'}`);
     return res.status(200).json(populated);
   } catch (err) {

--- a/src/controllers/health.js
+++ b/src/controllers/health.js
@@ -1,6 +1,7 @@
 import Logger from '../utils/logger.js'
 import mongoose from '../config/mongoose.js'
 import Config from '../config/config.js';
+import { getRealtimeStatus } from '../socket/index.js';
 
 const HealthService = {
 
@@ -22,7 +23,18 @@ const HealthService = {
     const dbStatus = mongoose && mongoose.connection.readyState === 1 ? 'UP' : 'DOWN';
     const version = Config.appVersion;
 
-    return res.status(200).json({ dbStatus, version });
+    return res.status(200).json({ dbStatus, version, realtime: getRealtimeStatus() });
+  },
+
+  realtime: async (req, res) => {
+    Logger.info('Realtime status');
+
+    const realtime = getRealtimeStatus();
+    // Socket server not initialized is the only hard failure; a Redis outage
+    // degrades to the in-memory adapter and is still reported 200.
+    const code = realtime.socket === 'UP' ? 200 : 503;
+
+    return res.status(code).json(realtime);
   },
 
 }

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -12,6 +12,7 @@ router.get('/', (req, res) => {
 })
   //health and status
   .get('/health', HealthController.health)
-  .get('/status', HealthController.status);
+  .get('/status', HealthController.status)
+  .get('/realtime', HealthController.realtime);
 
 export default router;

--- a/src/socket/index.js
+++ b/src/socket/index.js
@@ -1,0 +1,180 @@
+import { Server } from 'socket.io';
+import jwt from 'jsonwebtoken';
+import { createAdapter } from '@socket.io/redis-adapter';
+import { createClient } from 'redis';
+import Config from '../config/config.js';
+import Logger from '../utils/logger.js';
+
+let io = null;
+let redisPubClient = null;
+let redisSubClient = null;
+
+const meetingRoom = (meetingId) => `meeting:${meetingId}`;
+
+/**
+ * Attach the Redis adapter so events fan out across multiple server instances.
+ * Fire-and-forget: on any failure we log and keep the default in-memory adapter,
+ * so a single instance (or a Redis outage) still works.
+ */
+async function attachRedisAdapter(server, url) {
+  try {
+    redisPubClient = createClient({
+      url,
+      socket: {
+        connectTimeout: 10000,
+        // Bounded backoff so a misconfigured Redis doesn't retry forever.
+        reconnectStrategy: (retries) =>
+          retries > 10 ? false : Math.min(retries * 200, 3000),
+      },
+    });
+    redisSubClient = redisPubClient.duplicate();
+
+    redisPubClient.on('error', (err) =>
+      Logger.error(`Redis pub client error: ${err.message}`)
+    );
+    redisSubClient.on('error', (err) =>
+      Logger.error(`Redis sub client error: ${err.message}`)
+    );
+
+    await Promise.all([redisPubClient.connect(), redisSubClient.connect()]);
+    server.adapter(createAdapter(redisPubClient, redisSubClient));
+    Logger.info('Socket.IO Redis adapter connected');
+  } catch (err) {
+    Logger.error(
+      `Socket.IO Redis adapter failed, falling back to in-memory: ${err.message}`
+    );
+  }
+}
+
+/** Verify a JWT from the socket handshake; mirrors the HTTP authn middleware. */
+function verifyHandshake(socket) {
+  let token =
+    socket.handshake?.auth?.token ||
+    socket.handshake?.headers?.authorization ||
+    socket.handshake?.query?.token;
+
+  if (typeof token === 'string' && token.startsWith('Bearer ')) {
+    token = token.slice(7);
+  }
+
+  if (!token) {
+    return null;
+  }
+
+  const decoded = jwt.verify(token, process.env.TOKEN_SECRET);
+  if (!decoded?.userID) {
+    return null;
+  }
+  return decoded;
+}
+
+/** Attach a Socket.IO server to the given HTTP server. Safe to call once at boot. */
+export function initSocket(server) {
+  io = new Server(server, {
+    // Mirror the permissive HTTP CORS (see app.js). Tighten alongside it if locked down.
+    cors: { origin: true, credentials: true },
+    // WebSocket-only: avoids the multi-request polling handshake, so no ALB
+    // sticky sessions are required when running multiple instances.
+    transports: ['websocket'],
+  });
+
+  io.use((socket, next) => {
+    try {
+      const decoded = verifyHandshake(socket);
+      if (!decoded) {
+        return next(new Error('Not authorized'));
+      }
+      socket.decoded = decoded;
+      return next();
+    } catch (err) {
+      Logger.error(`Socket auth failed: ${err.message}`);
+      return next(new Error('Not authorized'));
+    }
+  });
+
+  io.on('connection', (socket) => {
+    socket.on('meeting:join', (meetingId) => {
+      if (meetingId) {
+        socket.join(meetingRoom(meetingId));
+      }
+    });
+
+    socket.on('meeting:leave', (meetingId) => {
+      if (meetingId) {
+        socket.leave(meetingRoom(meetingId));
+      }
+    });
+  });
+
+  if (Config.redisURL) {
+    attachRedisAdapter(io, Config.redisURL);
+  } else {
+    Logger.info('Socket.IO using in-memory adapter (no REDIS_URL configured)');
+  }
+
+  Logger.info('Socket.IO initialized');
+  return io;
+}
+
+export function getIO() {
+  return io;
+}
+
+/**
+ * Realtime subsystem status for health checks.
+ * `redis` is DISABLED when no REDIS_URL is set, UP when both clients are ready,
+ * otherwise DOWN (in which case the server transparently uses the in-memory adapter).
+ */
+export function getRealtimeStatus() {
+  const redisConfigured = !!Config.redisURL;
+  let redis = 'DISABLED';
+  let adapter = 'in-memory';
+
+  if (redisConfigured) {
+    const ready = !!redisPubClient?.isReady && !!redisSubClient?.isReady;
+    redis = ready ? 'UP' : 'DOWN';
+    adapter = ready ? 'redis' : 'in-memory';
+  }
+
+  return {
+    socket: io ? 'UP' : 'DOWN',
+    connectedClients: io?.engine?.clientsCount ?? 0,
+    adapter,
+    redis,
+  };
+}
+
+/** Gracefully close the socket server and Redis clients (called on shutdown signals). */
+export async function closeSocket() {
+  try {
+    if (io) {
+      await io.close();
+    }
+  } catch (err) {
+    Logger.error(`Error closing Socket.IO: ${err.message}`);
+  }
+  for (const client of [redisPubClient, redisSubClient]) {
+    try {
+      if (client?.isOpen) {
+        await client.quit();
+      }
+    } catch (err) {
+      Logger.error(`Error closing Redis client: ${err.message}`);
+    }
+  }
+}
+
+/**
+ * Broadcast the latest (populated) meeting to everyone viewing it.
+ * No-op if sockets are not initialized (e.g. in scripts/tests).
+ */
+export function emitMeetingUpdate(meeting) {
+  if (!io || !meeting) {
+    return;
+  }
+  const id = String(meeting._id || meeting.id || '');
+  if (!id) {
+    return;
+  }
+  io.to(meetingRoom(id)).emit('meeting:updated', meeting);
+}


### PR DESCRIPTION
Promote current develop to staging for QA.

Includes the real-time meeting sync feature (Socket.IO, optional Redis adapter, EB nginx websocket config, /realtime health endpoint). Paired with thff-fuse2 develop→staging.

Note: set `REDIS_URL` in the staging EB env only if running multiple instances; otherwise it runs in-memory (fine for single instance).

Made with [Cursor](https://cursor.com)