### PR TITLE
Promote develop → staging: long-polling transport fix

### DIFF
--- a/src/socket/index.js
+++ b/src/socket/index.js
@@ -73,9 +73,11 @@ export function initSocket(server) {
   io = new Server(server, {
     // Mirror the permissive HTTP CORS (see app.js). Tighten alongside it if locked down.
     cors: { origin: true, credentials: true },
-    // WebSocket-only: avoids the multi-request polling handshake, so no ALB
-    // sticky sessions are required when running multiple instances.
-    transports: ['websocket'],
+    // HTTP long-polling first (works on App Runner, which does not support
+    // WebSockets), then auto-upgrade to WebSocket if the platform allows it
+    // (e.g. after migrating to ECS). Long-polling requires a single instance
+    // or sticky sessions since the session is pinned to one process.
+    transports: ['polling', 'websocket'],
   });
 
   io.use((socket, next) => {


### PR DESCRIPTION
App Runner has no WebSocket support; switch Socket.IO to HTTP long-polling for near-instant meeting sync on staging. Paired with thff-fuse2.

Made with [Cursor](https://cursor.com)