### PR TITLE
chore(release): bump to 5.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thff-be",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thff-be",
-      "version": "5.6.2",
+      "version": "5.6.3",
       "license": "MIT",
       "dependencies": {
         "@socket.io/redis-adapter": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-be",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "description": "hagen family foundation backend",
   "main": "app.js",
   "type": "module",


### PR DESCRIPTION
Patch bump for the live meeting sync feature (Socket.IO long-polling). Backend /status will report 5.6.3.

Made with [Cursor](https://cursor.com)