### PR TITLE
feat(meeting): add a proposal to a meeting regardless of year (THFF-155)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-be",
-  "version": "5.6.9",
+  "version": "5.6.10",
   "description": "hagen family foundation backend",
   "main": "app.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-be",
-  "version": "5.6.10",
+  "version": "5.6.11",
   "description": "hagen family foundation backend",
   "main": "app.js",
   "type": "module",

--- a/src/controllers/admin/meetings.js
+++ b/src/controllers/admin/meetings.js
@@ -1,4 +1,5 @@
 import { validationResult } from "express-validator";
+import mongoose from "mongoose";
 
 import Meeting from "../../models/meeting.js";
 import Organization from "../../models/organization.js";
@@ -676,6 +677,83 @@ export const syncEligibleProposalsToMeeting = async (req, res) => {
   } catch (err) {
     Logger.error(`Error syncing eligible proposals: ${err.message}`);
     return res.status(500).json({ code: "MTG038", message: err.message });
+  }
+};
+
+/**
+ * Add a single proposal to a meeting as an allocation, regardless of the proposal's year.
+ * Unlike sync-eligible-proposals (which only pulls proposals whose createdAt falls in the
+ * meeting year), this lets a president/admin hand-pick any proposal — e.g. one submitted
+ * after the portal closed, or dated to a different cycle.
+ *
+ * Body: { proposalId: string }
+ * Idempotent — if the proposal already has an allocation on the meeting, returns unchanged.
+ */
+export const addProposalToMeeting = async (req, res) => {
+  Logger.verbose('Inside addProposalToMeeting');
+
+  try {
+    const { decoded } = req;
+    if (!isPresidentOrAdmin(decoded)) {
+      return res.status(403).json({ code: "MTG051", message: "Only the president or admin can add proposals" });
+    }
+
+    const { id } = req.params;
+    const { proposalId } = req.body || {};
+
+    if (!proposalId || !mongoose.isValidObjectId(String(proposalId))) {
+      return res.status(400).json({ code: "MTG052", message: "A valid proposalId is required" });
+    }
+
+    const meeting = await Meeting.findById(id);
+    if (!meeting) {
+      return res.status(404).json({ code: "MTG005", message: "Meeting not found" });
+    }
+
+    if (meeting.status !== 'setup' && meeting.status !== 'in_progress' && meeting.status !== 'completed') {
+      return res.status(400).json({ code: "MTG053", message: "Proposals can only be added during setup, while the meeting is in progress, or when editing a completed meeting" });
+    }
+
+    const proposal = await Proposal.findById(proposalId).select('_id organization amountRequested');
+    if (!proposal) {
+      return res.status(404).json({ code: "MTG054", message: "Proposal not found" });
+    }
+    if (!proposal.organization) {
+      return res.status(400).json({ code: "MTG055", message: "Proposal has no organization and cannot be added" });
+    }
+
+    const alreadyOnMeeting = meeting.allocations.some(
+      (a) => a.proposal && String(a.proposal) === String(proposal._id)
+    );
+
+    if (alreadyOnMeeting) {
+      const populated = await populateMeeting(id);
+      Logger.info(`addProposalToMeeting: proposal ${proposalId} already on meeting ${id} (no change)`);
+      return res.status(200).json(populated);
+    }
+
+    meeting.allocations.push({
+      proposal: proposal._id,
+      organization: proposal.organization,
+      amountRequested: proposal.amountRequested || 0,
+      amountGranted: 0,
+      activeInMeeting: true
+    });
+
+    if (meeting.status === 'completed') {
+      meeting.totalAllocated = sumGrantedActiveAllocations(meeting);
+    }
+
+    await meeting.save();
+
+    const populated = await populateMeeting(id);
+    emitMeetingUpdate(populated);
+
+    Logger.info(`addProposalToMeeting: proposal ${proposalId} added to meeting ${id}`);
+    return res.status(200).json(populated);
+  } catch (err) {
+    Logger.error(`Error adding proposal to meeting: ${err.message}`);
+    return res.status(500).json({ code: "MTG056", message: err.message });
   }
 };
 

--- a/src/controllers/proposal/proposals.js
+++ b/src/controllers/proposal/proposals.js
@@ -39,12 +39,42 @@ async function mongoOrganizationIdsForUser(user) {
   return [...ids];
 }
 
+/** Escape user input before using it in a RegExp so special chars don't break the query. */
+function escapeRegex(value) {
+  return String(value || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
- * Shared filter for director/org proposal lists (year window + archived + org + title).
- * @param {{ year: string|number, org?: string, filter?: string, showArchived?: string, viewerUserId?: string }} args
+ * Resolve a free-text search term to the organization and sponsor (User) ids whose name/email
+ * match it, so a proposal list `filter` can also match by organization name, sponsor name/email.
+ * Title and proposalID are matched directly on the Proposal and don't need this lookup.
+ * @param {string} filter
+ * @returns {Promise<{ orgIds: import('mongoose').Types.ObjectId[], sponsorIds: import('mongoose').Types.ObjectId[] }>}
+ */
+async function resolveProposalFilterRefs(filter) {
+  const term = String(filter || '').trim();
+  if (!term) {
+    return { orgIds: [], sponsorIds: [] };
+  }
+  const rx = new RegExp(escapeRegex(term), 'i');
+  const [orgs, sponsors] = await Promise.all([
+    Organization.find({ name: rx }).select('_id').lean(),
+    User.find({ $or: [{ firstName: rx }, { lastName: rx }, { email: rx }] }).select('_id').lean(),
+  ]);
+  return {
+    orgIds: orgs.map((o) => o._id),
+    sponsorIds: sponsors.map((u) => u._id),
+  };
+}
+
+/**
+ * Shared filter for director/org proposal lists (year window + archived + org + text search).
+ * The `filter` term matches project title, proposal ID, and — via pre-resolved id arrays —
+ * organization name and sponsor name/email.
+ * @param {{ year: string|number, org?: string, filter?: string, showArchived?: string, viewerUserId?: string, filterOrgIds?: any[], filterSponsorIds?: any[] }} args
  * When `org` is set: everyone sees `submitted`; the signed-in viewer also sees their own composer drafts (`createdBy`).
  */
-function buildProposalListQuery({ year, org, filter, showArchived, viewerUserId }) {
+function buildProposalListQuery({ year, org, filter, showArchived, viewerUserId, filterOrgIds = [], filterSponsorIds = [] }) {
   const startDate = new Date(`${year}-01-01T00:00:00.000Z`);
   const endDate = new Date(`${year}-12-31T23:59:59.999Z`);
 
@@ -80,8 +110,19 @@ function buildProposalListQuery({ year, org, filter, showArchived, viewerUserId 
     andParts.push({ status: { $nin: COMPOSER_PROPOSAL_STATUSES } });
   }
 
-  if (filter && String(filter).length !== 0) {
-    andParts.push({ projectTitle: { $regex: String(filter).toLowerCase(), $options: 'i' } });
+  if (filter && String(filter).trim().length !== 0) {
+    const rx = { $regex: escapeRegex(String(filter).trim()), $options: 'i' };
+    const searchOr = [
+      { projectTitle: rx },
+      { proposalID: rx },
+    ];
+    if (filterOrgIds.length > 0) {
+      searchOr.push({ organization: { $in: filterOrgIds } });
+    }
+    if (filterSponsorIds.length > 0) {
+      searchOr.push({ sponsor: { $in: filterSponsorIds } });
+    }
+    andParts.push({ $or: searchOr });
   }
 
   if (andParts.length === 1) {
@@ -613,12 +654,15 @@ export const getProposals = async (req, res) => {
     } = req.query;
 
     try {
+      const { orgIds, sponsorIds } = await resolveProposalFilterRefs(filter);
       const query = buildProposalListQuery({
         year,
         org,
         filter,
         showArchived,
         viewerUserId: req.decoded?.userID,
+        filterOrgIds: orgIds,
+        filterSponsorIds: sponsorIds,
       });
 
       const wantTotal =
@@ -670,12 +714,15 @@ export const getProposals = async (req, res) => {
 export const countProposals = async (req, res) => {
   try {
     const { year, org, filter, showArchived } = req.query;
+    const { orgIds, sponsorIds } = await resolveProposalFilterRefs(filter);
     const query = buildProposalListQuery({
       year,
       org,
       filter,
       showArchived,
       viewerUserId: req.decoded?.userID,
+      filterOrgIds: orgIds,
+      filterSponsorIds: sponsorIds,
     });
     const count = await Proposal.countDocuments(query);
     return res.status(200).json(count);

--- a/src/routes/api/meeting.js
+++ b/src/routes/api/meeting.js
@@ -21,6 +21,7 @@ router.get('/:id/outbound-emails/:emailId', OutboundEmailController.getMeetingGr
 router.get('/:id/outbound-emails', OutboundEmailController.listMeetingOutboundEmails);
 router.post('/:id/send-grant-notifications', OutboundEmailController.sendGrantMeetingNotifications);
 router.post('/:id/sync-eligible-proposals', MeetingController.syncEligibleProposalsToMeeting);
+router.post('/:id/allocation', MeetingController.addProposalToMeeting);
 router.post('/', validateCreateMeeting, MeetingController.createMeeting);
 router.put('/:id', validateUpdateMeeting, MeetingController.updateMeeting);
 router.put('/:id/allocations', validateUpdateAllocations, MeetingController.updateAllocations);


### PR DESCRIPTION
## Summary
- Adds `POST /meeting/:id/allocation` so a **president/admin** can hand-pick a single proposal into a meeting, even if its `createdAt` year differs from the meeting year. The existing auto-sync only ever pulls the meeting's own year, so there was no way to add an out-of-cycle proposal.
- Endpoint is idempotent (re-adding is a no-op), guarded by president/admin (`accessLevel >= 3`), recomputes totals when the meeting is completed, emits the meeting-update socket event, and returns the populated meeting.
- Broadens the shared proposal list/count search so `filter` matches **project title, proposal ID, organization name, and sponsor name/email** (with regex escaping). This improves the new add-proposal dialog and the director proposals list.
- Bumps version to 5.6.10.

Pairs with the thff-fuse2 PR (add-proposal dialog + button). Both target `develop`.

## Test plan
- [ ] As president/admin, `POST /meeting/:id/allocation` with a `{ proposalId }` from another year adds an allocation to the meeting.
- [ ] As a regular director (level 2), the same call returns 403.
- [ ] Re-adding a proposal already on the meeting returns the meeting unchanged (no duplicate allocation).
- [ ] Invalid/missing `proposalId` returns 400; unknown meeting/proposal returns 404.
- [ ] Proposal list search (`GET /proposal?...&filter=`) returns matches by title, proposal ID, org name, and sponsor name/email.

Made with [Cursor](https://cursor.com)