### PR TITLE
chore(security): resolve Dependabot alerts (THFF-156)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thff-be",
-  "version": "5.6.9",
+  "version": "5.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thff-be",
-      "version": "5.6.9",
+      "version": "5.6.10",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.700.0",
@@ -25,7 +25,7 @@
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
         "mailgun.js": "^13.2.0",
-        "mongoose": "^8.0.1",
+        "mongoose": "^8.24.1",
         "redis": "^6.1.0",
         "socket.io": "^4.8.3",
         "uuid": "^14.0.0",
@@ -1386,9 +1386,13 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/base-64": {
       "version": "1.0.0",
@@ -1512,13 +1516,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -1775,11 +1781,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
@@ -3544,9 +3545,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.23.0",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.23.0.tgz",
-      "integrity": "sha512-Bul4Ha6J8IqzFrb0B1xpVzkC3S0sk43dmLSnhFOn8eJlZiLwL5WO6cRymmjaADdCMjUcCpj2ce8hZI6O4ZFSug==",
+      "version": "8.24.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.1.tgz",
+      "integrity": "sha512-UpHBA0l5kHyKJQFjmBaFYQFo5sgz1DK0TRqDkOyBLYbqiIbKKhIvBpHWBXqeo0rgW4kGI1UhhAw+kTQZoj1BdA==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.4",
@@ -4497,9 +4498,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-be",
-  "version": "5.6.9",
+  "version": "5.6.10",
   "description": "hagen family foundation backend",
   "main": "app.js",
   "type": "module",
@@ -33,14 +33,15 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "mailgun.js": "^13.2.0",
-    "mongoose": "^8.0.1",
+    "mongoose": "^8.24.1",
     "redis": "^6.1.0",
     "socket.io": "^4.8.3",
     "uuid": "^14.0.0",
     "winston": "^3.11.0"
   },
   "overrides": {
-    "tar": "^7.5.16"
+    "tar": "^7.5.21",
+    "brace-expansion": "^5.0.8"
   },
   "devDependencies": {
     "@babel/core": "^7.29.6",


### PR DESCRIPTION
## Summary
Resolves the 3 open Dependabot alerts in `thff-be` and bumps the app version to `5.6.10`.

| Package | Change | Severity | Advisory |
|---|---|---|---|
| mongoose | `^8.0.1` → `^8.24.1` (resolved 8.24.1) | medium | GHSA-664h-wqgq-64gw (prototype pollution in update casting) |
| tar (override) | `^7.5.16` → `^7.5.21` (resolved 7.5.22) | medium | GHSA-r292-9mhp-454m (uncontrolled recursion DoS) |
| brace-expansion (override) | added `^5.0.8` (resolved 5.0.8) | high | GHSA-mh99-v99m-4gvg (unbounded expansion DoS) |

`brace-expansion` is a transitive dev/tooling dep (via `minimatch@3.x`); GitHub's advisory range (`<= 5.0.7`) means only `5.0.8` clears the alert, so it's pinned via `overrides`.

`thff-fuse2` has no open Dependabot alerts.

## Test plan
- [x] `npm install` succeeds
- [x] `npm audit` → 0 vulnerabilities
- [x] `npx eslint --version` works (tooling using minimatch/brace-expansion)
- [x] `import('mongoose')` loads 8.24.1
- [ ] CI passes on `develop`

Ref: THFF-156

Made with [Cursor](https://cursor.com)