### PR TITLE
fix(email): receivable From/Reply-To so grant replies don't bounce (THFF-159)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thff-be",
-  "version": "5.6.10",
+  "version": "5.6.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thff-be",
-      "version": "5.6.10",
+      "version": "5.6.13",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.700.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-be",
-  "version": "5.6.12",
+  "version": "5.6.13",
   "description": "hagen family foundation backend",
   "main": "app.js",
   "type": "module",

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -36,6 +36,13 @@ const Config = {
   mailgunDomain: process.env.MAILGUN_DOMAIN,
   mailgunKey: process.env.MAILGUN_KEY,
   interalEmailAddress: process.env.INTERNAL_EMAIL_ADDRESS,
+  /** Outbound From / Reply-To. Must use a domain that accepts mail (hagenfamilyfoundation.org). */
+  mailFrom:
+    process.env.MAIL_FROM
+    || 'The Hagen Family Foundation <admin@hagenfamilyfoundation.org>',
+  mailReplyTo:
+    process.env.MAIL_REPLY_TO
+    || 'The Hagen Family Foundation <support@hagenfamilyfoundation.org>',
 
   /** Grant-cycle reminder cron (`npm run grant-cycle-emails`). Off until explicitly enabled. */
   grantCycleEmailsEnabled:

--- a/src/controllers/email/email.js
+++ b/src/controllers/email/email.js
@@ -31,12 +31,14 @@ export function sendHtmlEmail(to, subject, html) {
 
   const recipients = Array.isArray(to) ? to : [to];
 
+  // From/Reply-To must use hagenfamilyfoundation.org — hagenfoundation.org has no MX (replies bounce).
   return mg.messages
     .create(Config.mailgunDomain, {
-      from: 'The Hagen Family Foundation <admin@hagenfoundation.org>',
+      from: Config.mailFrom,
       to: recipients,
       subject,
       html,
+      'h:Reply-To': Config.mailReplyTo,
     })
     .then((body) => {
       Logger.info('Email sent successfully:', {


### PR DESCRIPTION
## Summary
- Outbound mail used `admin@hagenfoundation.org`, which has broken DNS (no MX), so grant award replies bounced ([THFF-159](https://thehagenfamilyfoundation.atlassian.net/browse/THFF-159), [THFF-160](https://thehagenfamilyfoundation.atlassian.net/browse/THFF-160)).
- From → `admin@hagenfamilyfoundation.org`, Reply-To → `support@hagenfamilyfoundation.org` (overridable via `MAIL_FROM` / `MAIL_REPLY_TO`).
- Version bump to **5.6.13**.

## Test plan
- [ ] Deploy and send a test email; confirm From/Reply-To headers
- [ ] Reply to the test email and confirm delivery to support@
- [ ] Note: already-sent grant emails still bounce on Reply — resend or ask orgs to use support@


Made with [Cursor](https://cursor.com)

[THFF-159]: https://thehagenfamilyfoundation.atlassian.net/browse/THFF-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[THFF-160]: https://thehagenfamilyfoundation.atlassian.net/browse/THFF-160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ