### PR TITLE
fix(email): Reply-To grants@hagenfamilyfoundation.org (THFF-159)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thff-be",
-  "version": "5.6.13",
+  "version": "5.6.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thff-be",
-      "version": "5.6.13",
+      "version": "5.6.14",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.700.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-be",
-  "version": "5.6.13",
+  "version": "5.6.14",
   "description": "hagen family foundation backend",
   "main": "app.js",
   "type": "module",

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -42,7 +42,7 @@ const Config = {
     || 'The Hagen Family Foundation <admin@hagenfamilyfoundation.org>',
   mailReplyTo:
     process.env.MAIL_REPLY_TO
-    || 'The Hagen Family Foundation <support@hagenfamilyfoundation.org>',
+    || 'The Hagen Family Foundation <grants@hagenfamilyfoundation.org>',
 
   /** Grant-cycle reminder cron (`npm run grant-cycle-emails`). Off until explicitly enabled. */
   grantCycleEmailsEnabled:


### PR DESCRIPTION
## Summary
- Change default Reply-To from `support@` to `grants@hagenfamilyfoundation.org` so grant award replies go to the grants inbox.
- Version bump to **5.6.14**.

## Test plan
- [ ] Confirm outbound emails have Reply-To: grants@hagenfamilyfoundation.org
- [ ] Reply to a test email and confirm delivery to grants@


Made with [Cursor](https://cursor.com)