### PR TITLE
chore: remove leftover hagenfoundation.org reference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thff-be",
-  "version": "5.6.14",
+  "version": "5.6.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thff-be",
-      "version": "5.6.14",
+      "version": "5.6.15",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.700.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-be",
-  "version": "5.6.14",
+  "version": "5.6.15",
   "description": "hagen family foundation backend",
   "main": "app.js",
   "type": "module",

--- a/src/controllers/email/email.js
+++ b/src/controllers/email/email.js
@@ -31,7 +31,6 @@ export function sendHtmlEmail(to, subject, html) {
 
   const recipients = Array.isArray(to) ? to : [to];
 
-  // From/Reply-To must use hagenfamilyfoundation.org — hagenfoundation.org has no MX (replies bounce).
   return mg.messages
     .create(Config.mailgunDomain, {
       from: Config.mailFrom,


### PR DESCRIPTION
## Summary
- Remove the last `hagenfoundation.org` mention (comment only) from thff-be.
- Confirmed none in thff-fuse2. Version **5.6.15**.

## Test plan
- [ ] `rg hagenfoundation.org` returns no matches in thff-be / thff-fuse2


Made with [Cursor](https://cursor.com)